### PR TITLE
Now the users can upload temp images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ docs/build
 
 #mongoDB key and firebase config
 .env
-

--- a/src/components/FileUploader.js
+++ b/src/components/FileUploader.js
@@ -196,8 +196,7 @@ const FileUploader = () => {
 					<p>
 						{index + 1}. {pregunta}
 					</p>
-					{ image && !images[image] ? <span className="text-danger">Parece que no has subido la imagen: { image }</span> : "" }
-					{ image && images[image] ? <img className="mb-2" src={ URL.createObjectURL(images[image]) } alt="image about question" /> : "" }
+					{ image ? renderImage(image) : "" }
 					{respuestas.map((respuesta, i) => {
 						const respuestaClassName = showAnswers
 							? respuesta.esRespuestaCorrecta
@@ -250,6 +249,22 @@ const FileUploader = () => {
 			);
 		});
 	};
+
+	const renderImage = (image) => {
+		if (images[image]) {
+			if (images[image].size > 40000)
+				return (<img className="mb-2" width={ "500px" } src={ URL.createObjectURL(images[image]) } alt="image about question" /> );
+
+			return (
+				<div className="d-flex flex-column">
+					<span className="text-warning mb-2">La imagen '{ image }' es demasiado pequeña. Se recomienda un tamaño mínimo de 500 píxeles de ancho.</span>
+					<img className="mb-2" width={ "500px" } src={ URL.createObjectURL(images[image]) } alt="image about question" />
+				</div>
+			);
+		}
+
+		return (<span className="text-danger">Parece que no has subido la imagen: { image }</span>);
+	}
 
 	const toggleShowAnswers = () => {
 		setRespuestasCorrectas(0);

--- a/src/components/FileUploader.js
+++ b/src/components/FileUploader.js
@@ -5,6 +5,7 @@ import alligator from "../images/alligator.gif";
 
 const FileUploader = () => {
 	const [selectedFile, setSelectedFile] = useState(null);
+	const [selectedFileImages, setSelectedFileImages] = useState(null);
 	const [preguntasRespuestasDesordenadas, setPreguntasRespuestasDesordenadas] =
 		useState([]);
 	const [showAnswers, setShowAnswers] = useState(false);
@@ -12,6 +13,9 @@ const FileUploader = () => {
 	const [respuestasCorrectas, setRespuestasCorrectas] = useState(0);
 	const [respuestasInCorrectas, setRespuestasInCorrectas] = useState(0);
 	const [maxPreguntas, setMaxPreguntas] = useState("todas");
+	const [images, setImages] = useState({});
+
+	const imagesDic = {};
 
 	useEffect(() => {
 		if (showAnswers) {
@@ -52,12 +56,41 @@ const FileUploader = () => {
 		}
 	};
 
+	const handleImageChage = (event) => {
+		const files = event.target.files;
+
+    	if (files && files.length > 0) {
+			const allImagesValid = Array.from(files).every((file) => file.type.startsWith("image/"));
+
+			if (allImagesValid) {
+				setSelectedFileImages(files);
+				return;
+			}
+		}
+
+		console.log("Solo se permiten subir archivos de imagen.");
+		setSelectedFileImages(null);
+	}
+
 	const handleFileUpload = () => {
 		if (!selectedFile) {
 			console.log("No se ha seleccionado ningún archivo.");
 			return;
 		}
 
+		if (selectedFileImages && selectedFileImages.length > 0) {
+			// wait images load
+			handleFileImagesUpload(() => {
+				play();
+			});
+
+			return;
+		}
+
+		play();
+	};
+
+	const play = () => {
 		setSelectedAnswers([]);
 		setShowAnswers(false);
 
@@ -87,10 +120,12 @@ const FileUploader = () => {
 			}
 
 			setPreguntasRespuestasDesordenadas(preguntasFiltradas);
+
+			setImages(imagesDic);
 		};
 
 		reader.readAsText(selectedFile);
-	};
+	}
 
 	const handleAnswerClick = (preguntaIndex, respuestaIndex) => {
 		const answerKey = `${preguntaIndex}-${respuestaIndex}`;
@@ -107,15 +142,62 @@ const FileUploader = () => {
 		}
 	};
 
+	const handleFileImagesUpload = (callback) => {
+		let counter = 0; 
+	  
+		const handleImageLoad = async (image, blob) => {
+			imagesDic[image.name] = blob;
+			counter++;
+		
+			if (counter === selectedFileImages.length) {
+				await callback();
+			}
+		};
+	  
+		// Iterar sobre cada imagen seleccionada
+		Array.from(selectedFileImages).forEach((image) => {
+			const reader = new FileReader();
+		
+			// Configurar la función de manejo de carga del lector
+			reader.onload = (e) => {
+				const dataUrl = e.target.result;
+				const blob = dataURLToBlob(dataUrl);
+		
+				// Llamar a la función de manejo de carga de imagen
+				handleImageLoad(image, blob);
+			};
+		
+			// Leer el contenido de la imagen como URL de datos
+			reader.readAsDataURL(image);
+		});
+	};
+	  
+
+	const dataURLToBlob = (dataUrl) => {
+		const parts = dataUrl.split(';base64,');
+		const contentType = parts[0].split(':')[1];
+		const raw = window.atob(parts[1]);
+		const rawLength = raw.length;
+		const uInt8Array = new Uint8Array(rawLength);
+
+		for (let i = 0; i < rawLength; ++i) {
+			uInt8Array[i] = raw.charCodeAt(i);
+		}
+
+		return new Blob([uInt8Array], { type: contentType });
+	}
+
 	const renderRespuestas = () => {
 		return preguntasRespuestasDesordenadas.map((item, index) => {
-			const { pregunta, respuestas } = item;
+			const { pregunta, respuestas, image } = item;
 
 			return (
 				<div key={index}>
 					<p>
 						{index + 1}. {pregunta}
 					</p>
+					{ image && !images[image] ? <span className="text-danger">Parece que no has subido la imagen: { image }</span> : "" }
+					{ image && images[image] ? <img className="mb-2" src={ URL.createObjectURL(images[image]) } alt="image about question" /> : "" }
 					{respuestas.map((respuesta, i) => {
 						const respuestaClassName = showAnswers
 							? respuesta.esRespuestaCorrecta
@@ -177,25 +259,56 @@ const FileUploader = () => {
 
 	return (
 		<div className={`${styles.container} container`}>
-			<div>
-				<input
-					id="fileInput"
-					type="file"
-					accept=".txt"
-					placeholder="Sube tus preguntas"
-					onChange={handleFileChange}
-					className={styles.customInput}
-				/>
-				<input
-					type="text"
-					value={maxPreguntas}
-					onChange={(event) => setMaxPreguntas(event.target.value)}
-					placeholder="Número de preguntas"
-					className={styles.inputText}
-				/>
-				<button onClick={handleFileUpload}>¡Desordenar!</button>
+			<div className="row">
+				<div className="col">
+					<div className="d-flex flex-column">
+						<span>Preguntas:</span>
+						<input
+							id="fileInput"
+							type="file"
+							accept=".txt"
+							placeholder="Sube tus preguntas"
+							onChange={handleFileChange}
+							className={styles.customInput}
+						/>
+					</div>
+				</div>
+				<div className="col">
+					<div className="d-flex flex-column">
+						<span>Imágenes asociadas a las preguntas:</span>
+						<input
+							type="file"
+							id="imgInput"
+							accept="image/*"
+							placeholder="Sube las imágenes asociadas a las preguntas"
+							onChange={ handleImageChage }
+							className={styles.customInput}
+							multiple
+						/>
+					</div>
+				</div>
 			</div>
-			<div className="text-container">
+			<div className="row">
+				<div className="col">
+					<div className="d-flex flex-column">
+						<span>Número de preguntas:</span>
+						<input
+							type="text"
+							value={maxPreguntas}
+							onChange={(event) => setMaxPreguntas(event.target.value)}
+							placeholder="Número de preguntas"
+							className={styles.inputText}
+						/>
+					</div>
+				</div>
+				<div className="col">
+					<div className="d-flex flex-column">
+						<span className="invisible">spacer</span>
+						<button onClick={handleFileUpload}>¡Desordenar!</button>
+					</div>
+				</div>
+			</div>
+			<div className="text-container mt-2">
 				<h2>Preguntas y respuestas desordenadas:</h2>
 				{preguntasRespuestasDesordenadas.length < 1 && (
 					<img src={alligator} alt="Animated GIF" width="70%" height="70%" />

--- a/src/components/FileUploader.module.css
+++ b/src/components/FileUploader.module.css
@@ -26,6 +26,10 @@ input[type="file"] {
 	margin-bottom: 10px;
 }
 
+input {
+	margin-right: 5px;
+}
+
 button {
 	padding: 13px 20px;
 	background-color: #5630bc;

--- a/src/functions/fileFunctions.js
+++ b/src/functions/fileFunctions.js
@@ -19,6 +19,7 @@ export function desordenarPreguntasRespuestas(texto) {
 				pregunta: line.substring(3), // Eliminar el prefijo '?:'
 				respuestas: [],
 				respuestasCorrectas: [],
+				image: null
 			};
 			preguntasRespuestas.push(preguntaActual);
 		} else if (line.startsWith("$")) {
@@ -27,6 +28,10 @@ export function desordenarPreguntasRespuestas(texto) {
 			respuesta = respuesta.substring(2); // Eliminar el prefijo 'a.', 'b.', 'c.', 'd.'
 			preguntaActual.respuestas.push(respuesta);
 			preguntaActual.respuestasCorrectas.push(respuesta);
+		} else if (line.startsWith("[") && line.endsWith("]")) { // Find image
+			const nameImage = line.substring(1, line.length - 1);
+
+			preguntaActual.image = nameImage;
 		} else if (
 			// Respuesta normal
 			line.startsWith("a.") ||
@@ -67,6 +72,7 @@ export function desordenarPreguntasRespuestas(texto) {
 			return {
 				pregunta: pregunta.pregunta,
 				respuestas: respuestasDesordenadas,
+				image: pregunta.image
 			};
 		}
 	);


### PR DESCRIPTION
Añadí la funcionalidad para poder añadir una imagen en las preguntas, por ejemplo en un pregunta que muestra un código y hace un pregunta sobre el mismo.

Las imágenes se suben temporalmente en el navegador del cliente mediante un FileReader y un Blob, parecido a como lo haces con los txt. Valido que sólo puedan subir imágenes y se pueden seleccionar varias.

El funcionamiento es el siguiente:

Tiene el siguiente txt:
`?: ¿Cuál es la primera ley de la arquitectura del software?
[image.png]
$a. Todo en arquitectura es una solución de compromiso
b. Un arquitecto de software no debe mezclarse con ingenieros
c. Todo sistema software debe tener unos planos
d. Individuos e interacciones sobre procesos y herramientas


?: ¿Cuál es la primera ley de la arquitectura del software?
$a. Todo en arquitectura es una solución de compromiso
b. Un arquitecto de software no debe mezclarse con ingenieros
c. Todo sistema software debe tener unos planos
d. Individuos e interacciones sobre procesos y herramientas`

Si quieres tener una imagen en una pregunta en específico, añades el nombre de la imagen entre corchetes. Después en el otro input de imágenes selccionas la imagen con ese nombre. Si no se sube la imagen o se sube con otro nombre alerto en esa pregunta con el mensaje "Parece que no has subido la imagen: { image }".

Espero que te sirva :)